### PR TITLE
Add Tilt duration to the setup log

### DIFF
--- a/components/venetian_blinds/venetian_blinds.cpp
+++ b/components/venetian_blinds/venetian_blinds.cpp
@@ -175,16 +175,16 @@ void VenetianBlinds::recompute_position_() {
   this->position = this->exact_position_ / (float)action_duration;
   this->tilt = this->exact_tilt_ / (float)this->tilt_duration;
 
-  ESP_LOGCONFIG(TAG, "  Direction %i", direction);
-  ESP_LOGCONFIG(TAG, "  Action duration: %i", action_duration);
-  ESP_LOGCONFIG(TAG, "  Tilt duration: %u", this->tilt_duration);
-  ESP_LOGCONFIG(TAG, "  Tilt boundary: %i", tilt_boundary);
-  ESP_LOGCONFIG(TAG, "  Now - last recompute: %u", now - this->last_recompute_time_);
-  ESP_LOGCONFIG(TAG, "    Tilt overlow: %i", tilt_overflow);
-  ESP_LOGCONFIG(TAG, "    Exact Tilt: %i", this->exact_tilt_);
-  ESP_LOGCONFIG(TAG, "    Exact Position: %i", this->exact_position_);
-  ESP_LOGCONFIG(TAG, "      tilt: %.3f", this->tilt);
-  ESP_LOGCONFIG(TAG, "      position: %.3f", this->position);
+//   ESP_LOGCONFIG(TAG, "  Direction %i", direction);
+//   ESP_LOGCONFIG(TAG, "  Action duration: %i", action_duration);
+//   ESP_LOGCONFIG(TAG, "  Tilt duration: %u", this->tilt_duration);
+//   ESP_LOGCONFIG(TAG, "  Tilt boundary: %i", tilt_boundary);
+//   ESP_LOGCONFIG(TAG, "  Now - last recompute: %u", now - this->last_recompute_time_);
+//   ESP_LOGCONFIG(TAG, "    Tilt overlow: %i", tilt_overflow);
+//   ESP_LOGCONFIG(TAG, "    Exact Tilt: %i", this->exact_tilt_);
+//   ESP_LOGCONFIG(TAG, "    Exact Position: %i", this->exact_position_);
+//   ESP_LOGCONFIG(TAG, "      tilt: %.3f", this->tilt);
+//   ESP_LOGCONFIG(TAG, "      position: %.3f", this->position);
 
   this->last_recompute_time_ = now;
 }

--- a/components/venetian_blinds/venetian_blinds.cpp
+++ b/components/venetian_blinds/venetian_blinds.cpp
@@ -13,7 +13,13 @@ void VenetianBlinds::dump_config() {
     LOG_COVER("", "Venetian Blinds", this);
     ESP_LOGCONFIG(TAG, "  Open Duration: %.1fs", this->open_duration / 1e3f);
     ESP_LOGCONFIG(TAG, "  Close Duration: %.1fs", this->close_duration / 1e3f);
-    ESP_LOGCONFIG(TAG, "  Tilt Duration: %.1fs", this->tilt_duration / 1e3f);
+    ESP_LOGCONFIG(TAG, "  Tilt Open/Close Duration: %.1fs", this->tilt_duration / 1e3f);
+    ESP_LOGCONFIG(TAG, "  Open Net Duration: %.1fs", this->open_net_duration_ / 1e3f);
+    ESP_LOGCONFIG(TAG, "  Close Net Duration: %.1fs", this->close_net_duration_ / 1e3f);
+    ESP_LOGCONFIG(TAG, "  Position: %.1f%", this->position);
+    ESP_LOGCONFIG(TAG, "  Exact Position: %.1fs", this->exact_position_ / 1e3f);
+    ESP_LOGCONFIG(TAG, "  Tilt: %.1f%", this->tilt);
+    ESP_LOGCONFIG(TAG, "  Exact Tilt: %.1fs", this->exact_tilt_ / 1e3f);
 }
 
 void VenetianBlinds::setup() {
@@ -24,6 +30,11 @@ void VenetianBlinds::setup() {
         this->position = 0.0;
         this->tilt = 0.0;
     }
+    this->open_net_duration_ = this->open_duration - this->tilt_duration;
+    this->close_net_duration_ = this->close_duration - this->tilt_duration;
+
+    this->exact_position_ = this->close_duration * this->position; // position factor should be same for both open and close even if both durations are different
+    this->exact_tilt_ = this->tilt_duration * this->tilt;
 }
 
 CoverTraits VenetianBlinds::get_traits() {

--- a/components/venetian_blinds/venetian_blinds.cpp
+++ b/components/venetian_blinds/venetian_blinds.cpp
@@ -165,8 +165,8 @@ void VenetianBlinds::recompute_position_() {
 
   const uint32_t now = millis();
   this->exact_tilt_ += direction * (now - this->last_recompute_time_);
-  this->exact_tilt_ = clamp(this->exact_tilt_, 0, (int)this->tilt_duration);
   const int tilt_overflow = direction * (this->exact_tilt_ - tilt_boundary);
+  this->exact_tilt_ = clamp(this->exact_tilt_, 0, (int)this->tilt_duration);
   if (tilt_overflow > 0) {
     this->exact_position_ += direction * tilt_overflow;
     this->exact_position_ = clamp(this->exact_position_, 0, action_duration);

--- a/components/venetian_blinds/venetian_blinds.cpp
+++ b/components/venetian_blinds/venetian_blinds.cpp
@@ -166,7 +166,7 @@ void VenetianBlinds::recompute_position_() {
   const uint32_t now = millis();
   this->exact_tilt_ += direction * (now - this->last_recompute_time_);
   this->exact_tilt_ = clamp(this->exact_tilt_, 0, (int)this->tilt_duration);
-  const int tilt_overflow = direction * (this->tilt - tilt_boundary);
+  const int tilt_overflow = direction * (this->exact_tilt_ - tilt_boundary);
   if (tilt_overflow > 0) {
     this->exact_position_ += direction * tilt_overflow;
     this->exact_position_ = clamp(this->exact_position_, 0, action_duration);

--- a/components/venetian_blinds/venetian_blinds.cpp
+++ b/components/venetian_blinds/venetian_blinds.cpp
@@ -33,7 +33,7 @@ void VenetianBlinds::setup() {
     this->open_net_duration_ = this->open_duration - this->tilt_duration;
     this->close_net_duration_ = this->close_duration - this->tilt_duration;
 
-    this->exact_position_ = this->close_duration * this->position; // position factor should be same for both open and close even if both durations are different
+    this->exact_position_ = this->close_net_duration_ * this->position; // position factor should be same for both open and close even if both durations are different
     this->exact_tilt_ = this->tilt_duration * this->tilt;
 }
 

--- a/components/venetian_blinds/venetian_blinds.cpp
+++ b/components/venetian_blinds/venetian_blinds.cpp
@@ -174,6 +174,17 @@ void VenetianBlinds::recompute_position_() {
 
   this->position = this->exact_position_ / action_dur;
   this->tilt = this->exact_tilt_ / this->tilt_duration;
+
+  ESP_LOGCONFIG(TAG, "  Dir %.1f", dir);
+  ESP_LOGCONFIG(TAG, "  Action duration: %u", action_dur);
+  ESP_LOGCONFIG(TAG, "  Tilt duration: %u", this->tilt_duration);
+  ESP_LOGCONFIG(TAG, "  Tilt boundary: %u", tilt_boundary);
+  ESP_LOGCONFIG(TAG, "    Tilt overlow: %u", tilt_overflow);
+  ESP_LOGCONFIG(TAG, "    Exact Tilt: %u", this->exact_tilt_);
+  ESP_LOGCONFIG(TAG, "    Exact Position: %u", this->exact_position_);
+  ESP_LOGCONFIG(TAG, "      tilt: %.3f", this->tilt);
+  ESP_LOGCONFIG(TAG, "      position: %.3f", this->position);
+
   this->last_recompute_time_ = now;
 }
 

--- a/components/venetian_blinds/venetian_blinds.cpp
+++ b/components/venetian_blinds/venetian_blinds.cpp
@@ -197,17 +197,6 @@ void VenetianBlinds::recompute_position_() {
   this->position = this->exact_position_ / (float)action_duration;
   this->tilt = this->exact_tilt_ / (float)this->tilt_duration;
 
-//   ESP_LOGCONFIG(TAG, "  Direction %i", direction);
-//   ESP_LOGCONFIG(TAG, "  Action duration: %i", action_duration);
-//   ESP_LOGCONFIG(TAG, "  Tilt duration: %u", this->tilt_duration);
-//   ESP_LOGCONFIG(TAG, "  Tilt boundary: %i", tilt_boundary);
-//   ESP_LOGCONFIG(TAG, "  Now - last recompute: %u", now - this->last_recompute_time_);
-//   ESP_LOGCONFIG(TAG, "    Tilt overlow: %i", tilt_overflow);
-//   ESP_LOGCONFIG(TAG, "    Exact Tilt: %i", this->exact_tilt_);
-//   ESP_LOGCONFIG(TAG, "    Exact Position: %i", this->exact_position_);
-//   ESP_LOGCONFIG(TAG, "      tilt: %.3f", this->tilt);
-//   ESP_LOGCONFIG(TAG, "      position: %.3f", this->position);
-
   this->last_recompute_time_ = now;
 }
 

--- a/components/venetian_blinds/venetian_blinds.cpp
+++ b/components/venetian_blinds/venetian_blinds.cpp
@@ -172,16 +172,16 @@ void VenetianBlinds::recompute_position_() {
     this->exact_position_ = clamp(this->exact_position_, 0, action_duration);
   }
 
-  this->position = this->exact_position_ / action_duration;
-  this->tilt = this->exact_tilt_ / this->tilt_duration;
+  this->position = this->exact_position_ / (float)action_duration;
+  this->tilt = this->exact_tilt_ / (float)this->tilt_duration;
 
   ESP_LOGCONFIG(TAG, "  Direction %i", direction);
-  ESP_LOGCONFIG(TAG, "  Action duration: %u", action_duration);
+  ESP_LOGCONFIG(TAG, "  Action duration: %i", action_duration);
   ESP_LOGCONFIG(TAG, "  Tilt duration: %u", this->tilt_duration);
-  ESP_LOGCONFIG(TAG, "  Tilt boundary: %u", tilt_boundary);
-  ESP_LOGCONFIG(TAG, "    Tilt overlow: %u", tilt_overflow);
-  ESP_LOGCONFIG(TAG, "    Exact Tilt: %u", this->exact_tilt_);
-  ESP_LOGCONFIG(TAG, "    Exact Position: %u", this->exact_position_);
+  ESP_LOGCONFIG(TAG, "  Tilt boundary: %i", tilt_boundary);
+  ESP_LOGCONFIG(TAG, "    Tilt overlow: %i", tilt_overflow);
+  ESP_LOGCONFIG(TAG, "    Exact Tilt: %i", this->exact_tilt_);
+  ESP_LOGCONFIG(TAG, "    Exact Position: %i", this->exact_position_);
   ESP_LOGCONFIG(TAG, "      tilt: %.3f", this->tilt);
   ESP_LOGCONFIG(TAG, "      position: %.3f", this->position);
 

--- a/components/venetian_blinds/venetian_blinds.cpp
+++ b/components/venetian_blinds/venetian_blinds.cpp
@@ -1,6 +1,6 @@
 #include "venetian_blinds.h"
-#include "esphome/core/log.h"
 #include "esphome/core/hal.h"
+#include "esphome/core/log.h"
 
 namespace esphome {
 namespace venetian_blinds {
@@ -10,95 +10,102 @@ static const char *TAG = "venetian_blinds.cover";
 using namespace esphome::cover;
 
 void VenetianBlinds::dump_config() {
-    LOG_COVER("", "Venetian Blinds", this);
-    ESP_LOGCONFIG(TAG, "  Open Duration: %.1fs", this->open_duration / 1e3f);
-    ESP_LOGCONFIG(TAG, "  Close Duration: %.1fs", this->close_duration / 1e3f);
-    ESP_LOGCONFIG(TAG, "  Tilt Open/Close Duration: %.1fs", this->tilt_duration / 1e3f);
-    ESP_LOGCONFIG(TAG, "  Open Net Duration: %.1fs", this->open_net_duration_ / 1e3f);
-    ESP_LOGCONFIG(TAG, "  Close Net Duration: %.1fs", this->close_net_duration_ / 1e3f);
-    ESP_LOGCONFIG(TAG, "  Position: %.1f%", this->position);
-    ESP_LOGCONFIG(TAG, "  Exact Position: %.1fs", this->exact_position_ / 1e3f);
-    ESP_LOGCONFIG(TAG, "  Tilt: %.1f%", this->tilt);
-    ESP_LOGCONFIG(TAG, "  Exact Tilt: %.1fs", this->exact_tilt_ / 1e3f);
+  LOG_COVER("", "Venetian Blinds", this);
+  ESP_LOGCONFIG(TAG, "  Open Duration: %.1fs", this->open_duration / 1e3f);
+  ESP_LOGCONFIG(TAG, "  Close Duration: %.1fs", this->close_duration / 1e3f);
+  ESP_LOGCONFIG(TAG, "  Tilt Open/Close Duration: %.1fs",
+                this->tilt_duration / 1e3f);
+  ESP_LOGCONFIG(TAG, "  Open Net Duration: %.1fs",
+                this->open_net_duration_ / 1e3f);
+  ESP_LOGCONFIG(TAG, "  Close Net Duration: %.1fs",
+                this->close_net_duration_ / 1e3f);
+  ESP_LOGCONFIG(TAG, "  Position: %.1f%", this->position);
+  ESP_LOGCONFIG(TAG, "  Tilt: %.1f%", this->tilt);
+  ESP_LOGCONFIG(TAG, "  Exact Position: %.1fs", this->exact_position_ / 1e3f);
+  ESP_LOGCONFIG(TAG, "  Exact Tilt: %.1fs", this->exact_tilt_ / 1e3f);
 }
 
 void VenetianBlinds::setup() {
-    auto restore = this->restore_state_();
-    if (restore.has_value()) {
-        restore->apply(this);
-    } else {
-        this->position = 0.0;
-        this->tilt = 0.0;
-    }
-    this->open_net_duration_ = this->open_duration - this->tilt_duration;
-    this->close_net_duration_ = this->close_duration - this->tilt_duration;
+  auto restore = this->restore_state_();
+  if (restore.has_value()) {
+    restore->apply(this);
+  } else {
+    this->position = 0.0;
+    this->tilt = 0.0;
+  }
+  this->open_net_duration_ = this->open_duration - this->tilt_duration;
+  this->close_net_duration_ = this->close_duration - this->tilt_duration;
 
-    this->exact_position_ = this->close_net_duration_ * this->position; // position factor should be same for both open and close even if both durations are different
-    this->exact_tilt_ = this->tilt_duration * this->tilt;
+  this->exact_position_ =
+      this->close_net_duration_ *
+      this->position; // position factor should be same for both open and close
+                      // even if both durations are different
+  this->exact_tilt_ = this->tilt_duration * this->tilt;
 }
 
 CoverTraits VenetianBlinds::get_traits() {
-    auto traits = CoverTraits();
-    traits.set_supports_position(true);
-    traits.set_supports_tilt(true);
-    traits.set_is_assumed_state(this->assumed_state);
-    return traits;
+  auto traits = CoverTraits();
+  traits.set_supports_position(true);
+  traits.set_supports_tilt(true);
+  traits.set_is_assumed_state(this->assumed_state);
+  return traits;
 }
 
 void VenetianBlinds::control(const CoverCall &call) {
-    if (call.get_stop()) {
-        this->start_direction_(COVER_OPERATION_IDLE);
-        this->publish_state();
-    }
-    if (call.get_position().has_value()) {
-        auto requested_position = *call.get_position();
-        if (requested_position != this->position) {
-            cover::CoverOperation operation;
-            uint32_t operation_duration;
-            if (requested_position < this->position) {
-               operation = COVER_OPERATION_CLOSING;
-               operation_duration = this->open_net_duration_;
-               this->target_tilt_ = 0.0f;
-            } else {
-               operation = COVER_OPERATION_OPENING;
-               operation_duration = this->close_net_duration_;
-               this->target_tilt_ = 1.0f;
-            }
+  if (call.get_stop()) {
+    this->start_direction_(COVER_OPERATION_IDLE);
+    this->publish_state();
+  }
+  if (call.get_position().has_value()) {
+    auto requested_position = *call.get_position();
+    if (requested_position != this->position) {
+      cover::CoverOperation operation;
+      uint32_t operation_duration;
+      if (requested_position < this->position) {
+        operation = COVER_OPERATION_CLOSING;
+        operation_duration = this->open_net_duration_;
+        this->target_tilt_ = 0.0f;
+      } else {
+        operation = COVER_OPERATION_OPENING;
+        operation_duration = this->close_net_duration_;
+        this->target_tilt_ = 1.0f;
+      }
 
-            this->target_position_ = requested_position * operation_duration;
-            this->start_direction_(operation);
-        }
+      this->target_position_ = requested_position * operation_duration;
+      this->start_direction_(operation);
     }
-    if(call.get_tilt().has_value()) {
-        auto requested_tilt = *call.get_tilt();
-        if (requested_tilt != this->tilt) {
-            auto operation = requested_tilt < this->tilt ? COVER_OPERATION_CLOSING : COVER_OPERATION_OPENING;
-            this->target_position_ = this->exact_position_;
-            this->target_tilt_ = requested_tilt * this->tilt_duration;
-            this->start_direction_(operation);
-        }
+  }
+  if (call.get_tilt().has_value()) {
+    auto requested_tilt = *call.get_tilt();
+    if (requested_tilt != this->tilt) {
+      auto operation = requested_tilt < this->tilt ? COVER_OPERATION_CLOSING
+                                                   : COVER_OPERATION_OPENING;
+      this->target_position_ = this->exact_position_;
+      this->target_tilt_ = requested_tilt * this->tilt_duration;
+      this->start_direction_(operation);
     }
+  }
 }
 
 void VenetianBlinds::loop() {
-    if (this->current_operation == COVER_OPERATION_IDLE)
-        return;
+  if (this->current_operation == COVER_OPERATION_IDLE)
+    return;
 
-    const uint32_t now = millis();
+  const uint32_t now = millis();
 
-    // Recompute position every loop cycle
-    this->recompute_position_();
+  // Recompute position every loop cycle
+  this->recompute_position_();
 
-    if (this->is_at_target_()) {
-        this->start_direction_(COVER_OPERATION_IDLE);
-        this->publish_state();
-    }
+  if (this->is_at_target_()) {
+    this->start_direction_(COVER_OPERATION_IDLE);
+    this->publish_state();
+  }
 
-    // Send current position every second
-    if (now - this->last_publish_time_ > 1000) {
-        this->publish_state(false);
-        this->last_publish_time_ = now;
-    }
+  // Send current position every second
+  if (now - this->last_publish_time_ > 1000) {
+    this->publish_state(false);
+    this->last_publish_time_ = now;
+  }
 }
 
 void VenetianBlinds::stop_prev_trigger_() {
@@ -110,13 +117,15 @@ void VenetianBlinds::stop_prev_trigger_() {
 
 bool VenetianBlinds::is_at_target_() const {
   switch (this->current_operation) {
-    case COVER_OPERATION_OPENING:
-      return this->exact_position_ >= this->target_position_ && this->exact_tilt_ >= this->target_tilt_;
-    case COVER_OPERATION_CLOSING:
-      return this->exact_position_ <= this->target_position_ && this->exact_tilt_ <= this->target_tilt_;
-    case COVER_OPERATION_IDLE:
-    default:
-      return true;
+  case COVER_OPERATION_OPENING:
+    return this->exact_position_ >= this->target_position_ &&
+           this->exact_tilt_ >= this->target_tilt_;
+  case COVER_OPERATION_CLOSING:
+    return this->exact_position_ <= this->target_position_ &&
+           this->exact_tilt_ <= this->target_tilt_;
+  case COVER_OPERATION_IDLE:
+  default:
+    return true;
   }
 }
 
@@ -127,19 +136,19 @@ void VenetianBlinds::start_direction_(CoverOperation dir) {
   this->recompute_position_();
   Trigger<> *trig;
   switch (dir) {
-    case COVER_OPERATION_IDLE:
-      trig = this->stop_trigger;
-      break;
-    case COVER_OPERATION_OPENING:
-      this->last_operation_ = dir;
-      trig = this->open_trigger;
-      break;
-    case COVER_OPERATION_CLOSING:
-      this->last_operation_ = dir;
-      trig = this->close_trigger;
-      break;
-    default:
-      return;
+  case COVER_OPERATION_IDLE:
+    trig = this->stop_trigger;
+    break;
+  case COVER_OPERATION_OPENING:
+    this->last_operation_ = dir;
+    trig = this->open_trigger;
+    break;
+  case COVER_OPERATION_CLOSING:
+    this->last_operation_ = dir;
+    trig = this->close_trigger;
+    break;
+  default:
+    return;
   }
 
   this->current_operation = dir;
@@ -161,21 +170,22 @@ void VenetianBlinds::recompute_position_() {
   int action_duration;
   int tilt_boundary;
   switch (this->current_operation) {
-    case COVER_OPERATION_OPENING:
-      direction = 1;
-      action_duration = this->open_net_duration_;
-      tilt_boundary = this->tilt_duration;
-      break;
-    case COVER_OPERATION_CLOSING:
-      direction = -1;
-      action_duration = this->close_net_duration_;
-      tilt_boundary = 0;
-      break;
-    default:
-      return;
+  case COVER_OPERATION_OPENING:
+    direction = 1;
+    action_duration = this->open_net_duration_;
+    tilt_boundary = this->tilt_duration;
+    break;
+  case COVER_OPERATION_CLOSING:
+    direction = -1;
+    action_duration = this->close_net_duration_;
+    tilt_boundary = 0;
+    break;
+  default:
+    return;
   }
 
   const uint32_t now = millis();
+
   this->exact_tilt_ += direction * (now - this->last_recompute_time_);
   const int tilt_overflow = direction * (this->exact_tilt_ - tilt_boundary);
   this->exact_tilt_ = clamp(this->exact_tilt_, 0, (int)this->tilt_duration);
@@ -201,5 +211,5 @@ void VenetianBlinds::recompute_position_() {
   this->last_recompute_time_ = now;
 }
 
-}
-}
+} // namespace venetian_blinds
+} // namespace esphome

--- a/components/venetian_blinds/venetian_blinds.cpp
+++ b/components/venetian_blinds/venetian_blinds.cpp
@@ -179,6 +179,7 @@ void VenetianBlinds::recompute_position_() {
   ESP_LOGCONFIG(TAG, "  Action duration: %i", action_duration);
   ESP_LOGCONFIG(TAG, "  Tilt duration: %u", this->tilt_duration);
   ESP_LOGCONFIG(TAG, "  Tilt boundary: %i", tilt_boundary);
+  ESP_LOGCONFIG(TAG, "  Now - last recompute: %u", now - this->last_recompute_time_);
   ESP_LOGCONFIG(TAG, "    Tilt overlow: %i", tilt_overflow);
   ESP_LOGCONFIG(TAG, "    Exact Tilt: %i", this->exact_tilt_);
   ESP_LOGCONFIG(TAG, "    Exact Position: %i", this->exact_position_);

--- a/components/venetian_blinds/venetian_blinds.cpp
+++ b/components/venetian_blinds/venetian_blinds.cpp
@@ -53,8 +53,18 @@ void VenetianBlinds::control(const CoverCall &call) {
     if (call.get_position().has_value()) {
         auto requested_position = *call.get_position();
         if (requested_position != this->position) {
-            auto operation = requested_position < this->position ? COVER_OPERATION_CLOSING : COVER_OPERATION_OPENING;
-            auto operation_duration = requested_position < this->position ? this->open_net_duration_ : this->close_net_duration_;
+            cover::CoverOperation operation;
+            uint32_t operation_duration;
+            if (requested_position < this->position) {
+               operation = COVER_OPERATION_CLOSING;
+               operation_duration = this->open_net_duration_;
+               this->target_tilt_ = 0.0f;
+            } else {
+               operation = COVER_OPERATION_OPENING;
+               operation_duration = this->close_net_duration_;
+               this->target_tilt_ = 1.0f;
+            }
+
             this->target_position_ = requested_position * operation_duration;
             this->start_direction_(operation);
         }
@@ -63,6 +73,7 @@ void VenetianBlinds::control(const CoverCall &call) {
         auto requested_tilt = *call.get_tilt();
         if (requested_tilt != this->tilt) {
             auto operation = requested_tilt < this->tilt ? COVER_OPERATION_CLOSING : COVER_OPERATION_OPENING;
+            this->target_position_ = this->exact_position_;
             this->target_tilt_ = requested_tilt * this->tilt_duration;
             this->start_direction_(operation);
         }

--- a/components/venetian_blinds/venetian_blinds.cpp
+++ b/components/venetian_blinds/venetian_blinds.cpp
@@ -145,18 +145,18 @@ void VenetianBlinds::recompute_position_() {
   if (this->current_operation == COVER_OPERATION_IDLE)
     return;
 
-  float dir;
-  uint32_t action_dur;
-  uint32_t tilt_boundary;
+  int direction;
+  int action_duration;
+  int tilt_boundary;
   switch (this->current_operation) {
     case COVER_OPERATION_OPENING:
-      dir = 1.0f;
-      action_dur = this->open_net_duration_;
+      direction = 1;
+      action_duration = this->open_net_duration_;
       tilt_boundary = this->tilt_duration;
       break;
     case COVER_OPERATION_CLOSING:
-      dir = -1.0f;
-      action_dur = this->close_net_duration_;
+      direction = -1;
+      action_duration = this->close_net_duration_;
       tilt_boundary = 0;
       break;
     default:
@@ -164,19 +164,19 @@ void VenetianBlinds::recompute_position_() {
   }
 
   const uint32_t now = millis();
-  this->exact_tilt_ += dir * (now - this->last_recompute_time_);
-  this->exact_tilt_ = clamp(this->exact_tilt_, uint32_t(0), this->tilt_duration);
-  const uint32_t tilt_overflow = dir * (this->tilt - tilt_boundary);
+  this->exact_tilt_ += direction * (now - this->last_recompute_time_);
+  this->exact_tilt_ = clamp(this->exact_tilt_, 0, (int)this->tilt_duration);
+  const int tilt_overflow = direction * (this->tilt - tilt_boundary);
   if (tilt_overflow > 0) {
-    this->exact_position_ += dir * tilt_overflow;
-    this->exact_position_ = clamp(this->exact_position_, uint32_t(0), action_dur);
+    this->exact_position_ += direction * tilt_overflow;
+    this->exact_position_ = clamp(this->exact_position_, 0, action_duration);
   }
 
-  this->position = this->exact_position_ / action_dur;
+  this->position = this->exact_position_ / action_duration;
   this->tilt = this->exact_tilt_ / this->tilt_duration;
 
-  ESP_LOGCONFIG(TAG, "  Dir %.1f", dir);
-  ESP_LOGCONFIG(TAG, "  Action duration: %u", action_dur);
+  ESP_LOGCONFIG(TAG, "  Direction %i", direction);
+  ESP_LOGCONFIG(TAG, "  Action duration: %u", action_duration);
   ESP_LOGCONFIG(TAG, "  Tilt duration: %u", this->tilt_duration);
   ESP_LOGCONFIG(TAG, "  Tilt boundary: %u", tilt_boundary);
   ESP_LOGCONFIG(TAG, "    Tilt overlow: %u", tilt_overflow);

--- a/components/venetian_blinds/venetian_blinds.cpp
+++ b/components/venetian_blinds/venetian_blinds.cpp
@@ -13,9 +13,10 @@ void VenetianBlinds::dump_config() {
     LOG_COVER("", "Venetian Blinds", this);
     ESP_LOGCONFIG(TAG, "  Open Duration: %.1fs", this->open_duration / 1e3f);
     ESP_LOGCONFIG(TAG, "  Close Duration: %.1fs", this->close_duration / 1e3f);
+    ESP_LOGCONFIG(TAG, "  Tilt Duration: %.1fs", this->tilt_duration / 1e3f);
 }
 
-void VenetianBlinds::setup() {   
+void VenetianBlinds::setup() {
     auto restore = this->restore_state_();
     if (restore.has_value()) {
         restore->apply(this);
@@ -87,7 +88,7 @@ void VenetianBlinds::loop() {
             this->tilt = exact_tilt/100.0;
             this->publish_state();
         }
-    } 
+    }
     else if(relative_pos < 0 || relative_tilt > 0) {
         if(this->current_action != COVER_OPERATION_OPENING) {
             this->open_trigger->trigger();

--- a/components/venetian_blinds/venetian_blinds.h
+++ b/components/venetian_blinds/venetian_blinds.h
@@ -32,12 +32,12 @@ class VenetianBlinds : public Component, public cover::Cover {
     uint32_t start_dir_time_{0};
     uint32_t last_recompute_time_{0};
     uint32_t last_publish_time_{0};
-    uint32_t exact_position_{0};
-    uint32_t exact_tilt_{0};
     uint32_t open_net_duration_;
     uint32_t close_net_duration_;
     uint32_t target_position_{0};
     uint32_t target_tilt_{0};
+    int exact_position_{0};
+    int exact_tilt_{0};
 
     void stop_prev_trigger_();
     bool is_at_target_() const;

--- a/components/venetian_blinds/venetian_blinds.h
+++ b/components/venetian_blinds/venetian_blinds.h
@@ -1,52 +1,54 @@
 #pragma once
-#include "esphome/core/component.h"
-#include "esphome/core/automation.h"
 #include "esphome/components/cover/cover.h"
+#include "esphome/core/automation.h"
+#include "esphome/core/component.h"
 
 namespace esphome {
 namespace venetian_blinds {
 
 class VenetianBlinds : public Component, public cover::Cover {
-  public:
-    void setup() override;
-    void loop() override;
-    void dump_config() override;
-    cover::CoverTraits get_traits() override;
-    void control(const cover::CoverCall &call) override;
-    Trigger<> *get_open_trigger() const { return this->open_trigger; }
-    Trigger<> *get_close_trigger() const { return this->close_trigger; }
-    Trigger<> *get_stop_trigger() const { return this->stop_trigger; }
-    void set_open_duration(uint32_t open) { this->open_duration = open; }
-    void set_close_duration(uint32_t close) { this->close_duration = close; }
-    void set_tilt_duration(uint32_t tilt) { this->tilt_duration = tilt; }
-    void set_assumed_state(bool value) { this->assumed_state = value; }
-  protected:
-    Trigger<> *open_trigger{new Trigger<>()};
-    Trigger<> *close_trigger{new Trigger<>()};
-    Trigger<> *stop_trigger{new Trigger<>()};
-    uint32_t open_duration;
-    uint32_t close_duration;
-    uint32_t tilt_duration;
-    bool assumed_state{false};
-  private:
-    uint32_t start_dir_time_{0};
-    uint32_t last_recompute_time_{0};
-    uint32_t last_publish_time_{0};
-    uint32_t open_net_duration_;
-    uint32_t close_net_duration_;
-    uint32_t target_position_{0};
-    uint32_t target_tilt_{0};
-    int exact_position_{0};
-    int exact_tilt_{0};
+public:
+  void setup() override;
+  void loop() override;
+  void dump_config() override;
+  cover::CoverTraits get_traits() override;
+  void control(const cover::CoverCall &call) override;
+  Trigger<> *get_open_trigger() const { return this->open_trigger; }
+  Trigger<> *get_close_trigger() const { return this->close_trigger; }
+  Trigger<> *get_stop_trigger() const { return this->stop_trigger; }
+  void set_open_duration(uint32_t open) { this->open_duration = open; }
+  void set_close_duration(uint32_t close) { this->close_duration = close; }
+  void set_tilt_duration(uint32_t tilt) { this->tilt_duration = tilt; }
+  void set_assumed_state(bool value) { this->assumed_state = value; }
 
-    void stop_prev_trigger_();
-    bool is_at_target_() const;
-    void start_direction_(cover::CoverOperation dir);
-    void recompute_position_();
+protected:
+  Trigger<> *open_trigger{new Trigger<>()};
+  Trigger<> *close_trigger{new Trigger<>()};
+  Trigger<> *stop_trigger{new Trigger<>()};
+  uint32_t open_duration;
+  uint32_t close_duration;
+  uint32_t tilt_duration;
+  bool assumed_state{false};
 
-    Trigger<> *prev_command_trigger_{nullptr};
-    cover::CoverOperation last_operation_{cover::COVER_OPERATION_OPENING};
+private:
+  uint32_t start_dir_time_{0};
+  uint32_t last_recompute_time_{0};
+  uint32_t last_publish_time_{0};
+  uint32_t open_net_duration_;
+  uint32_t close_net_duration_;
+  uint32_t target_position_{0};
+  uint32_t target_tilt_{0};
+  int exact_position_{0};
+  int exact_tilt_{0};
+
+  void stop_prev_trigger_();
+  bool is_at_target_() const;
+  void start_direction_(cover::CoverOperation dir);
+  void recompute_position_();
+
+  Trigger<> *prev_command_trigger_{nullptr};
+  cover::CoverOperation last_operation_{cover::COVER_OPERATION_OPENING};
 };
 
-}
-}
+} // namespace venetian_blinds
+} // namespace esphome

--- a/components/venetian_blinds/venetian_blinds.h
+++ b/components/venetian_blinds/venetian_blinds.h
@@ -15,19 +15,11 @@ class VenetianBlinds : public Component, public cover::Cover {
     void control(const cover::CoverCall &call) override;
     Trigger<> *get_open_trigger() const { return this->open_trigger; }
     Trigger<> *get_close_trigger() const { return this->close_trigger; }
-    Trigger<> *get_stop_trigger() const { return this->stop_trigger; }    
+    Trigger<> *get_stop_trigger() const { return this->stop_trigger; }
     void set_open_duration(uint32_t open) { this->open_duration = open; }
     void set_close_duration(uint32_t close) { this->close_duration = close; }
     void set_tilt_duration(uint32_t tilt) { this->tilt_duration = tilt; }
     void set_assumed_state(bool value) { this->assumed_state = value; }
-  private:
-    uint32_t last_position_update{0};
-    uint32_t last_tilt_update{0};
-    int exact_pos;
-    int relative_pos{0};
-    int exact_tilt;
-    int relative_tilt{0};
-    cover::CoverOperation current_action{cover::COVER_OPERATION_IDLE};
   protected:
     Trigger<> *open_trigger{new Trigger<>()};
     Trigger<> *close_trigger{new Trigger<>()};
@@ -36,6 +28,24 @@ class VenetianBlinds : public Component, public cover::Cover {
     uint32_t close_duration;
     uint32_t tilt_duration;
     bool assumed_state{false};
+  private:
+    uint32_t start_dir_time_{0};
+    uint32_t last_recompute_time_{0};
+    uint32_t last_publish_time_{0};
+    uint32_t exact_position_{0};
+    uint32_t exact_tilt_{0};
+    uint32_t open_net_duration_;
+    uint32_t close_net_duration_;
+    uint32_t target_position_{0};
+    uint32_t target_tilt_{0};
+
+    void stop_prev_trigger_();
+    bool is_at_target_() const;
+    void start_direction_(cover::CoverOperation dir);
+    void recompute_position_();
+
+    Trigger<> *prev_command_trigger_{nullptr};
+    cover::CoverOperation last_operation_{cover::COVER_OPERATION_OPENING};
 };
 
 }


### PR DESCRIPTION
* Uses ESPHome [TimeBasedCover](https://github.com/esphome/esphome/tree/dev/esphome/components/time_based) implementation as a base.
* Calculates tilt and position using milliseconds for open/close and tilt
* Tilt is no a part of position, so tilting from 0 to 100% does not change position 
* Unifies the tilt and position direction so that whenever position is closed tilt is closed as well
* Position calculation formula changes from conditions to following:
```
# veriables
direction_of_travel = 1 # -1 for close
move_time = now - last_recompute_time
tilt_boundary = tilt_duration # or zero for close

# calculation
tilt = tilt + direction_of_travel * move
tilt_overflow = (tilt-tilt_boundary) * direction_of_travel
position = position + direction_of_travel * tilt_delta if tilt_overflow > 0
```


